### PR TITLE
Fix MIN_MEASUREMENT support for IMPACT and WM counters

### DIFF
--- a/pyiskra/devices/IMPACT.py
+++ b/pyiskra/devices/IMPACT.py
@@ -93,7 +93,7 @@ class Impact(Device):
                 offset = 5400
             elif measurement_type == MeasurementType.MAX_MEASUREMENTS:
                 offset = 5500
-            elif measurement_type == MeasurementType.MAX_MEASUREMENTS:
+            elif measurement_type == MeasurementType.MIN_MEASUREMENTS:
                 offset = 5600
 
             interval_stats = None

--- a/pyiskra/devices/WM.py
+++ b/pyiskra/devices/WM.py
@@ -92,7 +92,7 @@ class WM(Device):
                 offset = 5400
             elif measurement_type == MeasurementType.MAX_MEASUREMENTS:
                 offset = 5500
-            elif measurement_type == MeasurementType.MAX_MEASUREMENTS:
+            elif measurement_type == MeasurementType.MIN_MEASUREMENTS:
                 offset = 5600
 
             interval_stats = None


### PR DESCRIPTION
Currently a typo was present where MAX_MEASUREMENT was present in two elif branches instead of one of them being MIN

Looking at [the docs](https://www.iskra.eu/f/docs/Smart-energy-meters/K_IE38Mx_EN_22433926_Users_manual_ver_1.04_1.pdf) min measurements start at 35700 so 5600 + 100 is the correct one for MIN_MEASUREMENT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Modbus offsets for minimum measurements on IMPACT devices, ensuring accurate retrieval of non-actual/minimum measurement data.
  * Fixed Modbus offset mapping for minimum measurements on WM devices to prevent incorrect readings and improve data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->