### PR TITLE
Add support for A²h/Ampere-squared hours in get_counter_units

### DIFF
--- a/pyiskra/helper.py
+++ b/pyiskra/helper.py
@@ -123,6 +123,8 @@ class CounterType(Enum):
     REACTIVE_EXPORT = "reactive_export"
     APPARENT_IMPORT = "apparent_import"
     APPARENT_EXPORT = "apparent_export"
+    SQUARED_IMPORT = "squared_import"
+    SQUARED_EXPORT = "squared_export"
     UNKNOWN = "unknown"
 
 

--- a/pyiskra/helper.py
+++ b/pyiskra/helper.py
@@ -167,11 +167,13 @@ class Counters:
 counter_units = ("", "Wh", "varh", "VAh")
 
 def get_counter_units(counter_parameter):
+    units = counter_parameter & 0x3
     # Check if counter is set to Ampere-squared hours
-    if counter_parameter & 0x20:
+    # Units must be 0 since 0x21-0x23 is reserved for Individual Phases
+    if counter_parameter & 0x20 and units == 0:
         return "AAh"    
     # first 2 bits only
-    return counter_units[counter_parameter & 0x3] 
+    return counter_units[units] 
 
 
 def get_counter_direction(quadrants, reverse_connection):

--- a/pyiskra/helper.py
+++ b/pyiskra/helper.py
@@ -193,23 +193,27 @@ def get_counter_direction(quadrants, reverse_connection):
     return direction
 
 
-def get_counter_type(direction, units):
-    if direction == "import":
-        if units == "Wh":
-            return CounterType.ACTIVE_IMPORT
-        elif units == "varh":
-            return CounterType.REACTIVE_IMPORT
-        elif units == "VAh":
-            return CounterType.APPARENT_IMPORT
-    elif direction == "export":
-        if units == "Wh":
-            return CounterType.ACTIVE_EXPORT
-        elif units == "varh":
-            return CounterType.REACTIVE_EXPORT
-        elif units == "VAh":
-            return CounterType.APPARENT_EXPORT
+COUNTER_UNITS = {
+    ("import", "Wh"): CounterType.ACTIVE_IMPORT,
+    ("import", "varh"): CounterType.REACTIVE_IMPORT,
+    ("import", "VAh"): CounterType.APPARENT_IMPORT,
+    ("import", "AAh"): CounterType.SQUARED_IMPORT,
+    ("export", "Wh"): CounterType.ACTIVE_EXPORT,
+    ("export", "varh"): CounterType.REACTIVE_EXPORT,
+    ("export", "VAh"): CounterType.APPARENT_EXPORT,
+    ("export", "AAh"): CounterType.SQUARED_EXPORT,
+}
 
-    return CounterType.UNKNOWN
+def get_counter_type(direction: str, units: str) -> CounterType:
+    """
+    Get the CounterType based on direction and units.
+    Args:
+        direction (str): The direction of the counter (e.g., "import", "export").
+        units (str): The units of the counter (e.g., "Wh", "varh", "VAh", "AAh").
+    Returns:
+        CounterType: The corresponding CounterType enum value.
+    """
+    return COUNTER_UNITS.get((direction, units), CounterType.UNKNOWN)
 
 
 class ModbusMapper:

--- a/pyiskra/helper.py
+++ b/pyiskra/helper.py
@@ -162,9 +162,12 @@ class Counters:
         self.resettable = resettable if resettable is not None else []
 
 
-counter_units = ["", "Wh", "varh", "VAh"]
+counter_units = ("", "Wh", "varh", "VAh")
 
 def get_counter_units(counter_parameter):
+    # Check if counter is set to Ampere-squared hours
+    if counter_parameter & 0x20:
+        return "AAh"    
     # first 2 bits only
     return counter_units[counter_parameter & 0x3] 
 


### PR DESCRIPTION
A check for bit 5 was added (0x20) which is used to indicate Squared Current.

Before:
`Resettable counter Value: 200.0, Direction: import`
After:
`Resettable counter Value: 200.0AAh, Direction: import`

Also switched `counter_units` to an immutable tuple since it fits the purpose better 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recognizes Ampere-squared hours (AAh) as a counter unit.
  * Distinguishes squared import vs. squared export so measurements display correctly.

* **Refactor**
  * Streamlined unit detection with an explicit unit-to-type mapping for more consistent identification and safe fallback to "unknown" when unmatched.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->